### PR TITLE
Bc 6267

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ install-deps:
 	case $(_PYTHON_VENV) in python3*) yum install -y ${shell echo $(_PYTHON_VENV) | tr -d .}; esac
 	@# in centos:7 python dependencies required gcc
 	case $(_PYTHON_VENV) in python3*) yum install gcc -y; esac
-	virtualenv --system-site-packages -p /usr/bin/$(_PYTHON_VENV) $(VENVNAME); \
+	virtualenv -p /usr/bin/$(_PYTHON_VENV) $(VENVNAME); \
 	. $(VENVNAME)/bin/activate; \
 	pip install -U pip; \
 	pip install --upgrade setuptools; \

--- a/repos/system_upgrade/cloudlinux/actors/checkrhnclienttools/libraries/version.py
+++ b/repos/system_upgrade/cloudlinux/actors/checkrhnclienttools/libraries/version.py
@@ -24,6 +24,10 @@ class Version(object):
     def __eq__(self, other):
         return self.value == other.value
 
+    # Added due to linter rule asking for this
+    def __hash__(self):
+        return hash(self._raw)
+
     def __gt__(self, other):
         return any(
             [v[0] > v[1] for v in zip(self.value, other.value)]

--- a/repos/system_upgrade/common/actors/filterrpmtransactionevents/actor.py
+++ b/repos/system_upgrade/common/actors/filterrpmtransactionevents/actor.py
@@ -65,7 +65,11 @@ class FilterRpmTransactionTasks(Actor):
         # run upgrade for the rest of RH signed pkgs which we do not have rule for
         to_upgrade = installed_pkgs - (to_install | to_remove | to_reinstall)
 
-        self.log.debug('DNF modules to enable: {}'.format(modules_to_enable.keys()))
+        # Iterating over keys here due to linter complaints
+        dbg = '';
+        for k, v in modules_to_enable.items():
+            dbg = dbg + k + ' ';
+        self.log.debug('DNF modules to enable: '.dbg)
 
         self.produce(FilteredRpmTransactionTasks(
             local_rpms=list(local_rpms),

--- a/repos/system_upgrade/common/actors/setuptargetrepos/libraries/setuptargetrepos.py
+++ b/repos/system_upgrade/common/actors/setuptargetrepos/libraries/setuptargetrepos.py
@@ -144,7 +144,11 @@ def process():
 
     custom_repos.extend(vendor_repos)
 
-    api.current_logger().debug('Used repos: {}'.format(used_repoids_dict.keys()))
+    # Iterating over keys here due to linter complaints
+    dbg = '';
+    for k, v in modules_to_enable.items():
+        dbg = dbg + k + ' ';
+    api.current_logger().debug('Used repos: '.dbg)
     api.current_logger().debug('Enabled repos: {}'.format(list(enabled_repoids)))
 
     # TODO(pstodulk): isn't that a potential issue that we map just enabled repos

--- a/repos/system_upgrade/common/libraries/rpms.py
+++ b/repos/system_upgrade/common/libraries/rpms.py
@@ -21,7 +21,10 @@ def get_installed_rpms():
 
 def create_lookup(model, field, keys, context=stdlib.api):
     """
-    Create a lookup set from one of the model fields.
+    Create a lookup list from one of the model fields.
+    Returns a list of keys instead of a set, as you might want to
+    access this data at some point later in some form of structured
+    manner. See package_data_for
 
     :param model: model class
     :param field: model field, its value will be taken for lookup data
@@ -30,20 +33,20 @@ def create_lookup(model, field, keys, context=stdlib.api):
     """
     data = getattr(next((m for m in context.consume(model)), model()), field)
     try:
-        return {tuple(getattr(obj, key) for key in keys) for obj in data} if data else set()
+        return [tuple(getattr(obj, key) for key in keys) for obj in data][0] if data else list()
     except TypeError:
         # data is not iterable, not lookup can be built
         stdlib.api.current_logger().error(
                 "{model}.{field}.{keys} is not iterable, can't build lookup".format(
                     model=model, field=field, keys=keys))
-        return set()
+        return list()
 
 
 def has_package(model, package_name, arch=None, version=None, release=None, context=stdlib.api):
     """
     Expects a model InstalledRedHatSignedRPM or InstalledUnsignedRPM.
     Can be useful in cases like a quick item presence check, ex. check in actor that
-    a certain package is installed.
+    a certain package is installed. Returns BOOL
     :param model: model class
     :param package_name: package to be checked
     :param arch: filter by architecture. None means all arches.
@@ -52,15 +55,25 @@ def has_package(model, package_name, arch=None, version=None, release=None, cont
     """
     if not (isinstance(model, type) and issubclass(model, InstalledRPM)):
         return False
-    keys = ['name']
-    if arch:
-        keys.append('arch')
-    if version:
-        keys.append('version')
-    if release:
-        keys.append('release')
+    return tuple(attributes) in package_data_for(model,package_name,arch,version,release,context)
+
+
+def package_data_for(model, package_name, arch=None, version=None, release=None, context=stdlib.api):
+    """
+    Expects a model InstalledRedHatSignedRPM or InstalledUnsignedRPM.
+    Useful for where we want to know a thing is installed
+    THEN do something based on the data.
+    Returns list( name, arch, version, release ) for given RPM.
+    :param model: model class
+    :param package_name: package to be checked
+    :param arch: filter by architecture. None means all arches.
+    :param version: filter by version. None means all versions.
+    :param release: filter by release. None means all releases.
+    """
+    if not (isinstance(model, type) and issubclass(model, InstalledRPM)):
+        return False
+    keys = ['name','arch','version','release']
 
     attributes = [package_name]
     attributes += [attr for attr in (arch, version, release) if attr is not None]
-    rpm_lookup = create_lookup(model, field='items', keys=keys, context=context)
-    return tuple(attributes) in rpm_lookup
+    return create_lookup(model, field='items', keys=keys, context=context)

--- a/repos/system_upgrade/wp-toolkit/.leapp/info
+++ b/repos/system_upgrade/wp-toolkit/.leapp/info
@@ -1,0 +1,1 @@
+{"name": "wp-toolkit", "id": "ae31666a-37b8-435c-a071-a3d28342099b", "repos": ["644900a5-c347-43a3-bfab-f448f46d9647"]}

--- a/repos/system_upgrade/wp-toolkit/.leapp/leapp.conf
+++ b/repos/system_upgrade/wp-toolkit/.leapp/leapp.conf
@@ -1,0 +1,6 @@
+
+[repositories]
+repo_path=${repository:root_dir}
+
+[database]
+path=${repository:state_dir}/leapp.db

--- a/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
@@ -28,15 +28,16 @@ class SetWpToolkitYumVariable(Actor):
     def _do_cpanel(self, version):
 
         files_to_copy = []
-        try:
-            with open(src_path, 'w') as var_file:
-                var_file.write(version)
+        if version is not None:
+            try:
+                with open(src_path, 'w') as var_file:
+                    var_file.write(version)
 
-            files_to_copy.append(CopyFile(src=src_path, dst=dst_path))
-            api.current_logger().debug('Requesting leapp to copy {} into the upgrade environment as {}'.format(src_path, dst_path))
+                files_to_copy.append(CopyFile(src=src_path, dst=dst_path))
+                api.current_logger().debug('Requesting leapp to copy {} into the upgrade environment as {}'.format(src_path, dst_path))
 
-        except OSError as e:
-            api.current_logger().error('Cannot write to {}: {}'.format(e.filename, e.strerror))
+            except OSError as e:
+                api.current_logger().error('Cannot write to {}: {}'.format(e.filename, e.strerror))
 
         return TargetUserSpacePreupgradeTasks(copy_files=files_to_copy)
 
@@ -54,7 +55,6 @@ class SetWpToolkitYumVariable(Actor):
                 preupgrade_task = self._do_cpanel(wptk_data.version)
             else:
                 api.current_logger().warn('Could not recognize a supported environment for WP Toolkit.')
-                return
 
             api.produce(preupgrade_task)
 

--- a/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
@@ -47,7 +47,7 @@ class SetWpToolkitYumVariable(Actor):
             active_vendors.extend(vendor_list.data)
 
         if VENDOR_NAME in active_vendors:
-            wptk_data = api.consume(WpToolkit).next()
+            wptk_data = next(api.consume(WpToolkit), WpToolkit())
 
             preupgrade_task = None
             if wptk_data.variant == 'cpanel':

--- a/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
@@ -47,7 +47,7 @@ class SetWpToolkitYumVariable(Actor):
             active_vendors.extend(vendor_list.data)
 
         if VENDOR_NAME in active_vendors:
-            wptk_data = api.consume(WpToolkit)
+            wptk_data = api.consume(WpToolkit).next()
 
             preupgrade_task = None
             if wptk_data.variant == 'cpanel':

--- a/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
@@ -1,0 +1,61 @@
+import os
+
+from leapp.actors import Actor
+from leapp.models import ActiveVendorList, CopyFile, TargetUserSpacePreupgradeTasks
+from leapp.libraries.stdlib import api, run, CalledProcessError
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+VENDOR_NAME = 'wp-toolkit-cpanel'
+
+src_path = '/etc/leapp/files/vendors.d/wp-toolkit-cpanel.var'
+dst_path = '/etc/dnf/vars/wptkversion'
+
+class SetWpToolkitYumVariable(Actor):
+    """
+    Records the current WP Toolkit version into a DNF variable file so that the
+    precise version requested is reinstalled, and forwards the request to copy
+    this data into the upgrading environment using a
+    :class:`TargetUserSpacePreupgradeTasks`.
+    """
+
+    name = 'set_wp_toolkit_yum_variable'
+    consumes = (ActiveVendorList,)
+    produces = (TargetUserSpacePreupgradeTasks,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+
+        active_vendors = []
+        for vendor_list in api.consume(ActiveVendorList):
+            active_vendors.extend(vendor_list.data)
+
+        if VENDOR_NAME in active_vendors:
+
+            results = None
+            wptk_version = ''
+            try:
+                results = run([ '/usr/bin/rpm', '-q', '--queryformat=%{VERSION}', 'wp-toolkit-cpanel' ])
+                wptk_version = results['stdout']
+                api.current_logger().info('Detected WPTK version: {}'.format(wptk_version))
+            except CalledProcessError as e:
+                api.current_logger().warn('Could not find the version of WP Toolkit in the RPM database.')
+                return
+
+            try:
+                with open(src_path, 'w') as var_file:
+                    var_file.write(wptk_version)
+            except OSError as e:
+                api.current_logger().error('Cannot write to {}: {}'.format(e.filename, e.strerror))
+                return
+
+
+            files_to_copy = []
+            if os.path.isfile(src_path):
+                files_to_copy.append(CopyFile(src=src_path, dst=dst_path))
+                api.current_logger().debug('Requesting leapp to copy {} into the upgrade environment as {}'.format(src_path, dst_path))
+
+            preupgrade_task = TargetUserSpacePreupgradeTasks(copy_files=files_to_copy)
+            api.produce(preupgrade_task)
+
+        else:
+            api.current_logger().info('{} not an active vendor: skipping actor'.format(VENDOR_NAME))

--- a/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
@@ -1,16 +1,15 @@
-import os
-
 from leapp.actors import Actor
 from leapp.models import ActiveVendorList, CopyFile, TargetUserSpacePreupgradeTasks, WpToolkit
-from leapp.libraries.stdlib import api, run, CalledProcessError
+from leapp.libraries.stdlib import api
 from leapp.tags import TargetTransactionFactsPhaseTag, IPUWorkflowTag
 
 VENDOR_NAME = 'wp-toolkit'
-SUPPORTED_VARIANTS = ['cpanel',]
+SUPPORTED_VARIANTS = ['cpanel', ]
 
 # XXX Is src_path the best place to create this file?
 src_path = '/etc/leapp/files/vendors.d/wp-toolkit.var'
 dst_path = '/etc/dnf/vars/wptkversion'
+
 
 class SetWpToolkitYumVariable(Actor):
     """
@@ -34,7 +33,9 @@ class SetWpToolkitYumVariable(Actor):
                     var_file.write(version)
 
                 files_to_copy.append(CopyFile(src=src_path, dst=dst_path))
-                api.current_logger().debug('Requesting leapp to copy {} into the upgrade environment as {}'.format(src_path, dst_path))
+                # Only allocating this variable due to their linter rules on line length
+                dbg = 'Requesting leapp to copy {} into the upgrade environment as {}'.format(src_path, dst_path)
+                api.current_logger().debug(dbg)
 
             except OSError as e:
                 api.current_logger().error('Cannot write to {}: {}'.format(e.filename, e.strerror))

--- a/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
@@ -50,12 +50,11 @@ class SetWpToolkitYumVariable(Actor):
             wptk_data = api.consume(WpToolkit)
 
             preupgrade_task = None
-            match wptk_data.variant:
-                case 'cpanel':
-                    preupgrade_task = self._do_cpanel(wptk_data.version)
-                case _:
-                    api.current_logger().warn('Could not recognize a supported environment for WP Toolkit.')
-                    return
+            if wptk_data.variant == 'cpanel':
+                preupgrade_task = self._do_cpanel(wptk_data.version)
+            else:
+                api.current_logger().warn('Could not recognize a supported environment for WP Toolkit.')
+                return
 
             api.produce(preupgrade_task)
 

--- a/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/setwptoolkityumvariable/actor.py
@@ -50,7 +50,7 @@ class SetWpToolkitYumVariable(Actor):
             wptk_data = api.consume(WpToolkit)
 
             preupgrade_task = None
-            match wptk.variant:
+            match wptk_data.variant:
                 case 'cpanel':
                     preupgrade_task = self._do_cpanel(wptk_data.version)
                 case _:

--- a/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
@@ -29,7 +29,7 @@ class UpdateWpToolkitRepos(Actor):
 
         if VENDOR_NAME in active_vendors:
 
-            wptk_data = api.consume(WpToolkit)
+            wptk_data = api.consume(WpToolkit).next()
 
             src_file = api.get_file_path('{}-{}.el8.repo'. format(VENDOR_NAME, wptk_data.variant))
             dst_file = '{}/{}-{}.repo'.format(REPO_DIR, VENDOR_NAME, wptk_data.variant)

--- a/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
@@ -39,7 +39,7 @@ class UpdateWpToolkitRepos(Actor):
             except OSError as e:
                 api.current_logger().warn('Could not rename {} to {}: {}'.format(e.filename, e.filename2, e.strerror))
 
-            api.current_logger().info('Updating WPTK package repository file at {} using {}'.format(src_file, dst_file))
+            api.current_logger().info('Updating WPTK package repository file at {} using {}'.format(dst_file, src_file))
 
             try:
                 shutil.copy(src_file, dst_file)

--- a/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
@@ -3,10 +3,10 @@ import shutil
 
 from leapp.actors import Actor
 from leapp.libraries.stdlib import api, run
-from leapp.models import (ActiveVendorList,)
+from leapp.models import ActiveVendorList, WpToolkit
 from leapp.tags import IPUWorkflowTag, FirstBootPhaseTag
 
-VENDOR_NAME = 'wp-toolkit-cpanel'
+VENDOR_NAME = 'wp-toolkit'
 
 VENDORS_DIR = '/etc/leapp/files/vendors.d'
 REPO_DIR = '/etc/yum.repos.d'
@@ -17,7 +17,7 @@ class UpdateWpToolkitRepos(Actor):
     """
 
     name = 'update_wp_toolkit_repos'
-    consumes = (ActiveVendorList,)
+    consumes = (ActiveVendorList, WpToolkit)
     produces = ()
     tags = (IPUWorkflowTag, FirstBootPhaseTag)
 
@@ -29,8 +29,10 @@ class UpdateWpToolkitRepos(Actor):
 
         if VENDOR_NAME in active_vendors:
 
-            src_file = api.get_file_path(VENDOR_NAME + '.el8.repo')
-            dst_file = '{}/{}.repo'.format(REPO_DIR, VENDOR_NAME)
+            wptk_data = api.consume(WpToolkit)
+
+            src_file = api.get_file_path('{}-{}.el8.repo'. format(VENDOR_NAME, wptk_data.variant))
+            dst_file = '{}/{}-{}.repo'.format(REPO_DIR, VENDOR_NAME, wptk_data.variant)
 
             try:
                 os.rename(dst_file, dst_file + '.bak')

--- a/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
@@ -29,7 +29,7 @@ class UpdateWpToolkitRepos(Actor):
 
         if VENDOR_NAME in active_vendors:
 
-            wptk_data = api.consume(WpToolkit).next()
+            wptk_data = api.consume(WpToolkit)
 
             src_file = api.get_file_path('{}-{}.el8.repo'. format(VENDOR_NAME, wptk_data.variant))
             dst_file = '{}/{}-{}.repo'.format(REPO_DIR, VENDOR_NAME, wptk_data.variant)

--- a/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
@@ -29,7 +29,7 @@ class UpdateWpToolkitRepos(Actor):
 
         if VENDOR_NAME in active_vendors:
 
-            wptk_data = api.consume(WpToolkit)
+            wptk_data = next(api.consume(WpToolkit), WpToolkit())
 
             src_file = api.get_file_path('{}-{}.el8.repo'. format(VENDOR_NAME, wptk_data.variant))
             dst_file = '{}/{}-{}.repo'.format(REPO_DIR, VENDOR_NAME, wptk_data.variant)

--- a/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/updatewptoolkitrepos/actor.py
@@ -1,0 +1,47 @@
+import os
+import shutil
+
+from leapp.actors import Actor
+from leapp.libraries.stdlib import api, run
+from leapp.models import (ActiveVendorList,)
+from leapp.tags import IPUWorkflowTag, FirstBootPhaseTag
+
+VENDOR_NAME = 'wp-toolkit-cpanel'
+
+VENDORS_DIR = '/etc/leapp/files/vendors.d'
+REPO_DIR = '/etc/yum.repos.d'
+
+class UpdateWpToolkitRepos(Actor):
+    """
+    Replaces the WP Toolkit's old repo file from the CentOS 7 version with one appropriate for the new OS.
+    """
+
+    name = 'update_wp_toolkit_repos'
+    consumes = (ActiveVendorList,)
+    produces = ()
+    tags = (IPUWorkflowTag, FirstBootPhaseTag)
+
+    def process(self):
+
+        active_vendors = []
+        for vendor_list in api.consume(ActiveVendorList):
+            active_vendors.extend(vendor_list.data)
+
+        if VENDOR_NAME in active_vendors:
+
+            src_file = api.get_file_path(VENDOR_NAME + '.el8.repo')
+            dst_file = '{}/{}.repo'.format(REPO_DIR, VENDOR_NAME)
+
+            try:
+                os.rename(dst_file, dst_file + '.bak')
+            except OSError as e:
+                api.current_logger().warn('Could not rename {} to {}: {}'.format(e.filename, e.filename2, e.strerror))
+
+            api.current_logger().info('Updating WPTK package repository file at {} using {}'.format(src_file, dst_file))
+
+            try:
+                shutil.copy(src_file, dst_file)
+            except OSError as e:
+                api.current_logger().error('Could not update WPTK package repository file {}: {}'.format(e.filename2, e.strerror))
+        else:
+            api.current_logger().info('{} not an active vendor: skipping actor'.format(VENDOR_NAME))

--- a/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/actor.py
@@ -1,0 +1,46 @@
+from leapp.actors import Actor
+from leapp.libraries.stdlib import api, run
+from leapp.models import ActiveVendorList, WpToolkit
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+
+VENDOR_NAME = 'wp-toolkit'
+SUPPORTED_VARIANTS = ['cpanel',]
+
+class WpToolkitFacts(Actor):
+    """
+    No documentation has been provided for the wp_toolkit_facts actor.
+    """
+
+    name = 'wp_toolkit_facts'
+    consumes = (ActiveVendorList,)
+    produces = (WpToolkit,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+
+        active_vendors = []
+        for vendor_list in api.consume(ActiveVendorList):
+            active_vendors.extend(vendor_list.data)
+
+        if VENDOR_NAME in active_vendors:
+            api.current_logger().info('Vendor {} is active. Looking for information...'.format(VENDOR_NAME))
+
+            version = None
+            for variant in SUPPORTED_VARIANTS:
+                try:
+                    result = run(['/usr/bin/rpm', '-q', '--queryformat=%{VERSION}', 'wp-toolkit-{}'.format(variant)])
+                    version = result['stdout']
+                    break
+                except:
+                    api.current_logger().debug('Did not find WP Toolkit variant {}'.format(variant))
+
+            if version is None:
+                variant = None
+                api.current_logger().warn('No WP Toolkit package appears to be installed.')
+            else:
+                api.current_logger().info('Found WP Toolkit variant {}, version {}'.format(variant, version))
+
+            api.produce(WpToolkit(variant=variant, version=version))
+
+        else:
+            api.current_logger().info('{} not an active vendor: skipping actor'.format(VENDOR_NAME))

--- a/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/actor.py
+++ b/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/actor.py
@@ -23,7 +23,6 @@ class WpToolkitFacts(Actor):
 
         active_vendors = []
         for vendor_list in api.consume(ActiveVendorList):
-            api.current_logger().info('vendor_list.data: {}'.format(vendor_list.data))
             active_vendors.extend(vendor_list.data)
 
         if VENDOR_NAME in active_vendors:
@@ -32,7 +31,6 @@ class WpToolkitFacts(Actor):
             version = None
             for variant in SUPPORTED_VARIANTS:
                 pkgData = package_data_for(InstalledRPM, 'wp-toolkit-{}'.format(variant))
-                api.current_logger().info('pkgData: {}'.format(pkgData))
                 # name, arch, version, release
                 if pkgData:
                     version = pkgData[2]

--- a/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/tests/test_wptoolkitfacts.py
+++ b/repos/system_upgrade/wp-toolkit/actors/wptoolkitfacts/tests/test_wptoolkitfacts.py
@@ -1,0 +1,37 @@
+# XXX TODO this copies a lot from satellite_upgrade_facts.py, should probably make a fixture
+# for fake_package at the least?
+
+from leapp.models import InstalledRPM, RPM, ActiveVendorList, WpToolkit
+
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+
+
+def fake_package(pkg_name):
+    return RPM(name=pkg_name, version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+               pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51')
+
+
+WPTOOLKIT_RPM = fake_package('wp-toolkit-cpanel')
+
+
+def test_no_wptoolkit_vendor_present(current_actor_context):
+    current_actor_context.feed(ActiveVendorList(data=list(["jello"])), InstalledRPM(items=[]))
+    current_actor_context.run()
+    message = current_actor_context.consume(WpToolkit)
+    assert not message
+
+
+def test_no_wptoolkit_rpm_present(current_actor_context):
+    current_actor_context.feed(ActiveVendorList(data=list(['wp-toolkit'])), InstalledRPM(items=[]))
+    current_actor_context.run()
+    message = current_actor_context.consume(WpToolkit)
+    assert not hasattr(message, 'variant')
+    assert not hasattr(message, 'version')
+
+
+def test_wptoolkit_rpm_present(current_actor_context):
+    current_actor_context.feed(ActiveVendorList(data=list(['wp-toolkit'])), InstalledRPM(items=[WPTOOLKIT_RPM]))
+    current_actor_context.run()
+    message = current_actor_context.consume(WpToolkit)[0]
+    assert message.variant == 'cpanel'
+    assert message.version == '0.1'

--- a/repos/system_upgrade/wp-toolkit/files/wp-toolkit-cpanel.el8.repo
+++ b/repos/system_upgrade/wp-toolkit/files/wp-toolkit-cpanel.el8.repo
@@ -1,0 +1,11 @@
+[wp-toolkit-cpanel]
+name=WP Toolkit for cPanel
+baseurl=https://wp-toolkit.plesk.com/cPanel/CentOS-8-x86_64/latest/wp-toolkit/
+enabled=1
+gpgcheck=1
+
+[wp-toolkit-thirdparties]
+name=WP Toolkit third parties
+baseurl=https://wp-toolkit.plesk.com/cPanel/CentOS-8-x86_64/latest/thirdparty/
+enabled=1
+gpgcheck=1

--- a/repos/system_upgrade/wp-toolkit/models/wptoolkit.py
+++ b/repos/system_upgrade/wp-toolkit/models/wptoolkit.py
@@ -1,0 +1,9 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemFactsTopic
+
+
+class WpToolkit(Model):
+    topic = SystemFactsTopic
+
+    variant = fields.String()
+    version = fields.String()

--- a/repos/system_upgrade/wp-toolkit/models/wptoolkit.py
+++ b/repos/system_upgrade/wp-toolkit/models/wptoolkit.py
@@ -5,5 +5,5 @@ from leapp.topics import SystemFactsTopic
 class WpToolkit(Model):
     topic = SystemFactsTopic
 
-    variant = fields.String()
-    version = fields.String()
+    variant = fields.Nullable(fields.String())
+    version = fields.Nullable(fields.String())


### PR DESCRIPTION
Note: First commit in set was needed for me to even get to the point where I could run `ACTOR=wptoolkitfacts make test_no_lint`.

Not sure why they would *want* to rely on the system libraries for their virtualenv when all that does is create a versioning conflict with the `six` module. As such I got rid of that arg as it is also not necessary.

Second commit was me cleaning up crap about their modules whined about in the linter, particularly in the python 2 -> 3 compatibility scan. That sounded bad if that was throwing alarms.

That said, make test by itself fails, so the upstream maintainers probably aren't running their own infrastructure's makefile rules at all. Truly a tragedy.

Third commit in set contains actual goodie we'd want to shuffle upstream (unless we *want* to fix their build toolchain for them)